### PR TITLE
增加对象池

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -38,7 +38,9 @@
         "lezhnev74/pasvl": "^1.0",
         "rybakit/msgpack": "^0.9.0",
         "symfony/var-dumper": "^5.3",
-        "workerman/workerman": "^4.0"
+        "workerman/workerman": "^4.0",
+        "psr/cache": "^1.0",
+        "psr/log": "^1.1"
     },
     "require-dev": {
         "brainmaestro/composer-git-hooks": "^2.8",

--- a/src/OneBot/ObjectPool/AbstractObjectPool.php
+++ b/src/OneBot/ObjectPool/AbstractObjectPool.php
@@ -1,0 +1,90 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OneBot\ObjectPool;
+
+use Exception;
+use Swoole\Coroutine\Channel;
+
+/**
+ * 抽象对象池
+ * 只能在Swoole协程中使用
+ */
+abstract class AbstractObjectPool
+{
+    /** @var Channel 队列 */
+    private $queue;
+
+    /** @var array 活跃对象 */
+    private $actives;
+
+    public function __construct()
+    {
+        // TODO: 添加更多可配置项
+        $this->queue = new Channel(swoole_cpu_num());
+    }
+
+    /**
+     * 取出对象
+     *
+     * @throws Exception
+     */
+    public function take(): object
+    {
+        if ($this->getFreeCount() > 0) {
+            // 如有可用对象则取用
+            $object = $this->queue->pop(5);
+            if (!$object) {
+                throw new Exception('取出对象时等待超时');
+            }
+        } else {
+            // 没有就整个新的
+            $object = $this->makeObject();
+        }
+        $hash = spl_object_hash($object);
+        // 为方便在归还时删除，使用数组key存储
+        $this->actives[$hash] = '';
+
+        return $object;
+    }
+
+    /**
+     * 归还对象
+     */
+    public function return(object $object): bool
+    {
+        $hash = spl_object_hash($object);
+        unset($this->actives[$hash]);
+
+        // 放回队列里
+        return $this->queue->push($object, 5);
+    }
+
+    abstract protected function makeObject(): object;
+
+    /**
+     * 获取可用的对象数量
+     */
+    protected function getFreeCount(): int
+    {
+        $count = $this->queue->stats()['queue_num'];
+        return $count < 0 ? 0 : $count;
+    }
+
+    /**
+     * 获取活跃（已被取用）的对象数量
+     */
+    protected function getActiveCount(): int
+    {
+        return count($this->actives);
+    }
+
+    /**
+     * 获取所有的对象数量
+     */
+    protected function getTotalCount(): int
+    {
+        return $this->getFreeCount() + $this->getActiveCount();
+    }
+}


### PR DESCRIPTION
~~超级简单~~的测试用例：
```php
class ObjectPool extends \OneBot\ObjectPool\AbstractObjectPool
{
    public static $cc = 0;

    protected function makeObject(): object
    {
        return new Exception('Hello,' . self::$cc++);
    }
}

go(function () {
    $pool = new ObjectPool();
    echo 'HI!' . "\n";
    $object1 = $pool->take();
    echo '#1:';
    echo $object1->getMessage() . "\n";
    $object2 = $pool->take();
    echo '#2:';
    echo $object2->getMessage() . "\n";

    echo 'Back obj1' . "\n";
    $pool->return($object1);

    $object3 = $pool->take();
    echo '#3:';
    echo $object3->getMessage() . "\n";
});
```

输出：
```
HI!
#1:Hello,0
#2:Hello,1
Back obj1
#3:Hello,0
```