### PR TITLE
重构配置

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -34,8 +34,6 @@
         "php": "^7.2|^7.3|^7.4|^8.0|^8.1",
         "ext-json": "*",
         "ext-pdo": "*",
-        "hassankhan/config": "^2.2 || ^3.0",
-        "lezhnev74/pasvl": "^1.0",
         "psr/cache": "^1.0",
         "psr/http-client": "^1.0",
         "psr/log": "^1.1",

--- a/src/OneBot/Driver/Driver.php
+++ b/src/OneBot/Driver/Driver.php
@@ -40,7 +40,7 @@ abstract class Driver
         return $this->config;
     }
 
-    abstract public function initDriverProtocols(array $comm);
+    abstract public function initDriverProtocols(array $comm): void;
 
     abstract public function run();
 }

--- a/src/OneBot/Driver/SwooleDriver.php
+++ b/src/OneBot/Driver/SwooleDriver.php
@@ -29,29 +29,29 @@ class SwooleDriver extends Driver
      */
     protected $server;
 
-    public function initDriverProtocols(array $comm)
+    public function initDriverProtocols(array $comm): void
     {
-        $has_ws = false;
-        $has_http = false;
+        $ws_index = null;
+        $http_index = null;
         foreach ($comm as $k => $v) {
-            if ($v['type'] == 'ws') {
-                $has_ws = $k;
+            if ($v['type'] === 'websocket') {
+                $ws_index = $k;
             }
-            if ($v['type'] == 'http') {
-                $has_http = $k;
+            if ($v['type'] === 'http') {
+                $http_index = $k;
             }
         }
-        if ($has_ws !== false) {
-            $this->server = new SwooleWebSocketServer($comm[$has_ws]['host'], $comm[$has_ws]['port']);
+        if ($ws_index !== null) {
+            $this->server = new SwooleWebSocketServer($comm[$ws_index]['host'], $comm[$ws_index]['port']);
             $this->initServer();
-            if ($has_http !== false) {
+            if ($http_index !== null) {
                 ob_logger()->warning('检测到同时开启了http和正向ws，http的配置项将被忽略。');
                 $this->initHttpServer();
             }
             $this->initWebSocketServer();
-        } elseif ($has_http !== false) {
+        } elseif ($http_index !== null) {
             //echo "新建http服务器.\n";
-            $this->server = new SwooleHttpServer($comm[$has_http]['host'], $comm[$has_http]['port']);
+            $this->server = new SwooleHttpServer($comm[$http_index]['host'], $comm[$http_index]['port']);
             $this->initHttpServer();
         } else {
             go(function () {

--- a/src/OneBot/Driver/WorkermanDriver.php
+++ b/src/OneBot/Driver/WorkermanDriver.php
@@ -21,21 +21,21 @@ class WorkermanDriver extends Driver
 {
     protected $http_worker;
 
-    public function initDriverProtocols(array $comm)
+    public function initDriverProtocols(array $comm): void
     {
-        $has_http = false;
+        $http_index = null;
         foreach ($comm as $k => $v) {
-            if ($v['type'] == 'http') {
-                $has_http = $k;
+            if ($v['type'] === 'http') {
+                $http_index = $k;
             }
         }
-        if ($has_http !== false) {
+        if ($http_index !== null) {
             // 定义 Workerman 的 worker 和相关回调
-            $this->http_worker = new Worker('http://' . $comm[$has_http]['host'] . ':' . $comm[$has_http]['port']);
-            $this->http_worker->count = $comm[$has_http]['worker_count'] ?? 4;
+            $this->http_worker = new Worker('http://' . $comm[$http_index]['host'] . ':' . $comm[$http_index]['port']);
+            $this->http_worker->count = $comm[$http_index]['worker_count'] ?? 4;
             Worker::$internal_running = true; // 加上这句就可以不需要必须输 start 命令才能启动了，直接启动
             $this->initHttpServer();
-            $this->http_worker->onWorkerStart = function (Worker $worker) {
+            $this->http_worker->onWorkerStart = static function (Worker $worker) {
                 MPUtils::initProcess(ONEBOT_PROCESS_WORKER, $worker->id);
             };
         }

--- a/src/OneBot/Util/Utils.php
+++ b/src/OneBot/Util/Utils.php
@@ -8,7 +8,6 @@ use OneBot\V12\Action\ActionBase;
 use OneBot\V12\Exception\OneBotFailureException;
 use OneBot\V12\OneBot;
 use OneBot\V12\RetCode;
-use PASVL\Validation\ValidatorBuilder;
 
 class Utils
 {
@@ -43,17 +42,6 @@ class Utils
             $result = $message;
         }
         return $result;
-    }
-
-    /**
-     * 验证 $input 是否符合指定 $pattern.
-     *
-     * @see https://github.com/lezhnev74/pasvl
-     */
-    public static function validateArray(array $pattern, array $input)
-    {
-        $builder = ValidatorBuilder::forArray($pattern);
-        $builder->build()->validate($input);
     }
 
     public static function getActionFuncName(ActionBase $handler, string $action)

--- a/src/OneBot/V12/Config/Config.php
+++ b/src/OneBot/V12/Config/Config.php
@@ -4,130 +4,53 @@ declare(strict_types=1);
 
 namespace OneBot\V12\Config;
 
-use OneBot\Util\Utils;
-use OneBot\V12\Exception\OneBotException;
-
-class Config extends \Noodlehaus\Config implements ConfigInterface
+class Config implements ConfigInterface
 {
-    public function __construct($configPath)
-    {
-        parent::__construct($configPath);
+    /**
+     * @var array
+     */
+    private $config;
 
-        $this->validateConfig();
+    public function __construct(array $config)
+    {
+        $this->config = $config;
     }
 
+    /**
+     * {@inheritDoc}
+     */
+    public function get(string $key, $default = null)
+    {
+        // 在表层直接查找，找到就直接返回
+        if (array_key_exists($key, $this->config)) {
+            return $this->config[$key];
+        }
+
+        // 判断是否包含.，即是否读取多维数组，否则代表没有对应数据
+        if (strpos($key, '.') === false) {
+            return $default;
+        }
+
+        // 在多维数组中查找
+        $data = $this->config;
+        foreach (explode('.', $key) as $segment) {
+            // $data不是数组表示没有下级元素
+            // $segment不在数组中表示没有对应数据
+            if (!is_array($data) || !array_key_exists($segment, $data)) {
+                return $default;
+            }
+
+            $data = &$data[$segment];
+        }
+
+        return $data;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
     public function getEnabledCommunications(): array
     {
-        $enabled = [];
-        foreach ($this->get('communications', []) as $type => $config) {
-            if (isset($config['enable']) && $config['enable'] === false) {
-                continue;
-            }
-            if ($type === 'http' && ($config['enable'] ?? false) === true) {
-                $enabled[] = [
-                    'type' => $type,
-                    'host' => $config['host'] ?? '127.0.0.1',
-                    'port' => $config['port'] ?? 9600,
-                    'access_token' => $config['access_token'] ?? null,
-                ];
-            } elseif ($type === 'http_webhook' && Utils::isAssocArray($config) && ($config['enable'] ?? false) === true) {
-                $enabled[] = [
-                    'type' => $type,
-                    'url' => $config['url'],
-                    'access_token' => $config['access_token'] ?? null,
-                ];
-            } elseif ($type === 'http_webhooks' && !Utils::isAssocArray($config)) {
-                foreach ($config as $vs) {
-                    if (($vs['enable'] ?? false) === true) {
-                        $enabled[] = [
-                            'type' => 'http_webhook',
-                            'url' => $vs['url'],
-                            'access_token' => $vs['access_token'] ?? null,
-                        ];
-                    }
-                }
-            } elseif ($type === 'ws_reverse' && Utils::isAssocArray($config) && ($config['enable'] ?? false) === true) {
-                $enabled[] = [
-                    'type' => $type,
-                    'url' => $config['url'],
-                    'access_token' => $config['access_token'] ?? null,
-                ];
-            } elseif ($type === 'ws_reverses' && !Utils::isAssocArray($config)) {
-                foreach ($config as $ks => $vs) {
-                    if (($vs['enable'] ?? false) === true) {
-                        $enabled[] = [
-                            'type' => 'ws_reverse',
-                            'url' => $vs['url'],
-                            'access_token' => $vs['access_token'] ?? null,
-                        ];
-                    }
-                }
-            } elseif ($type === 'ws' && ($config['enable'] ?? false) === true) {
-                $enabled[] = [
-                    'type' => $type,
-                    'host' => $config['host'] ?? '127.0.0.1',
-                    'port' => $config['port'] ?? 9600,
-                    'access_token' => $config['access_token'] ?? null,
-                ];
-            } else {
-                throw new OneBotException(sprintf('Unsupported communication [%s].', $type));
-            }
-        }
-        return $enabled;
-    }
-
-    protected function validateConfig()
-    {
-        $pattern = [
-            'lib' => [
-                'db' => ':bool',
-            ],
-            'communications' => [
-                'http?' => [
-                    'enable' => ':bool',
-                    'host' => ":string :regexp('#((2(5[0-5]|[0-4]\\d))|[0-1]?\\d{1,2})(\\.((2(5[0-5]|[0-4]\\d))|[0-1]?\\d{1,2})){3}#')",
-                    'port' => ':number :int',
-                    'access_token?' => ':string',
-                    'event_enabled' => ':bool',
-                    'event_buffer_size' => ':number :int',
-                ],
-                'http_webhook?' => [
-                    'enable' => ':bool',
-                    'url' => ':string :url',
-                    'access_token?' => ':string',
-                    'timeout' => ':number :int',
-                ],
-                'http_webhooks?' => [
-                    '*' => [
-                        'enable' => ':bool',
-                        'url' => ':string :url',
-                        'access_token?' => ':string',
-                        'timeout' => ':number :int',
-                    ],
-                ],
-                'ws_reverse?' => [
-                    'enable' => ':bool',
-                    'url' => ':string :url',
-                    'access_token?' => ':string',
-                    'reconnected_interval' => ':number :int',
-                ],
-                'ws_reverses?' => [
-                    '*' => [
-                        'enable' => ':bool',
-                        'url' => ':string :url',
-                        'access_token?' => ':string',
-                        'reconnected_interval' => ':number :int',
-                    ],
-                ],
-                'ws?' => [
-                    'enable' => ':bool',
-                    'host' => ":string :regexp('#((2(5[0-5]|[0-4]\\d))|[0-1]?\\d{1,2})(\\.((2(5[0-5]|[0-4]\\d))|[0-1]?\\d{1,2})){3}#')",
-                    'port' => ':number :int',
-                    'access_token?' => ':string',
-                ],
-            ],
-        ];
-
-        Utils::validateArray($pattern, $this->all());
+        return $this->get('communications', []);
     }
 }

--- a/src/OneBot/V12/Config/ConfigInterface.php
+++ b/src/OneBot/V12/Config/ConfigInterface.php
@@ -6,7 +6,17 @@ namespace OneBot\V12\Config;
 
 interface ConfigInterface
 {
+    /**
+     * 获取配置项
+     *
+     * @param  string           $key     键名，使用.分割多维数组
+     * @param  mixed            $default 默认值
+     * @return null|array|mixed
+     */
     public function get(string $key, $default = null);
 
+    /**
+     * 获取启用的通讯方式
+     */
     public function getEnabledCommunications(): array;
 }

--- a/test/unit/ConfigTest.php
+++ b/test/unit/ConfigTest.php
@@ -1,11 +1,15 @@
 <?php
 
+declare(strict_types=1);
+
 namespace OneBot\V12\Config;
 
 use PHPUnit\Framework\TestCase;
 
 /**
  * @covers \OneBot\V12\Config\Config
+ *
+ * @internal
  */
 class ConfigTest extends TestCase
 {

--- a/test/unit/ConfigTest.php
+++ b/test/unit/ConfigTest.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace OneBot\V12\Config;
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @covers \OneBot\V12\Config\Config
+ */
+class ConfigTest extends TestCase
+{
+    /**
+     * @covers \OneBot\V12\Config\Config::get
+     */
+    public function testGetCanReturnExactValue(): void
+    {
+        $this->assertEquals('good', $this->getConfig()->get('top', 'bad'));
+    }
+
+    /**
+     * @covers \OneBot\V12\Config\Config::get
+     */
+    public function testGetCanReturnDefaultValue(): void
+    {
+        $this->assertEquals('bad', $this->getConfig()->get('middle', 'bad'));
+    }
+
+    /**
+     * @covers \OneBot\V12\Config\Config::get
+     */
+    public function testGetCanReturnDeepValue(): void
+    {
+        $this->assertEquals('good', $this->getConfig()->get('bottom.left', 'bad'));
+    }
+
+    private function getConfig(): Config
+    {
+        return new Config([
+            'top' => 'good',
+            'bottom' => [
+                'left' => 'good',
+                'right' => 'good',
+            ],
+        ]);
+    }
+}


### PR DESCRIPTION
允许用户直接传入配置数组，不关注配置来源。
根据数组中定义的配置进行初始化。

配置数组样例：
```php
$config = [
    'name' => 'repl',

    'platform' => 'qq',

    'self_id' => 'REPL-1',

    'db' => true,

    'logger' => [
        'class' => \OneBot\Logger\Console\ConsoleLogger::class,
        'level' => 'debug',
    ],

    'driver' => [
        'class' => \OneBot\Driver\SwooleDriver::class,
        'config' => [],
    ],

    'communications' => [
        [
            'type' => 'http',
            'host' => '127.0.0.1',
            'port' => 2345,
            'access_token' => '',
            'event_enabled' => true,
            'event_buffer_size' => 100,
        ],
        [
            'type' => 'webhook',
            'url' => '',
            'access_token' => '',
            'timeout' => 5,
        ],
        [
            'type' => 'websocket_reverse',
            'url' => '',
            'access_token' => '',
            'reconnect_interval' => 5,
        ],
    ],
];
```

代码：
```php
$ob = new OneBot(new Config($config));
$ob->setActionHandler(ReplAction::class);
$ob->run();
```

合并后可以移除 `hassankhan/config` `lezhnev74/pasvl` 依赖。