### PR TITLE
增加缺失的依赖

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -35,6 +35,7 @@
         "ext-json": "*",
         "ext-pdo": "*",
         "psr/cache": "^1.0",
+        "psr/event-dispatcher": "^1.0",
         "psr/http-client": "^1.0",
         "psr/log": "^1.1",
         "rybakit/msgpack": "^0.9.0",


### PR DESCRIPTION
项目中依赖了 `psr/event-dispatcher` 包，但并未在 `composer.json` 中明确声明，且其本身并非任一必需依赖的依赖。

在 [`EventDispatcher`](https://github.com/botuniverse/php-libonebot/blob/2fcdaf8105a1e1a4e594835abf0991d948fe75ec/src/OneBot/Driver/Event/EventDispatcher.php#L8) 类中，引入了 `Psr\EventDispatcher\EventDispatcherInterface` 接口，该接口归属于 `psr/event-dispatcher` 包。
该包并未在 `composer.json` 中声明，而是作为 `friendsofphp/php-cs-fixer` 的依赖被引入的，见：
```diff
$ composer why psr/event-dispatcher -t
psr/event-dispatcher 1.0.0 Standard interfaces for event handling.  
├──onebot/libonebot dev-develop (requires psr/event-dispatcher ^1.0)
└──symfony/event-dispatcher-contracts v2.5.0 (requires psr/event-dispatcher ^1)
   └──symfony/event-dispatcher v5.4.3 (requires symfony/event-dispatcher-contracts ^2|^3)
+     ├──friendsofphp/php-cs-fixer v3.4.0 (requires symfony/event-dispatcher ^4.4.20 || ^5.0 || ^6.0)
      │  └──onebot/libonebot dev-develop (requires (for development) friendsofphp/php-cs-fixer ^3.2)
      └──symfony/console v5.4.3 (conflicts symfony/event-dispatcher <4.4) (circular dependency aborted here)
```

由于 `friendsofphp/php-cs-fixer` 本身属于开发依赖，在生产环境中并不会引入，因此在生产环境中会造成 `psr/event-dispatcher` 包不存在的情况。