### PR TITLE
添加 Socket Flag

### DIFF
--- a/src/OneBot/Driver/Driver.php
+++ b/src/OneBot/Driver/Driver.php
@@ -248,8 +248,10 @@ abstract class Driver
 
     /**
      * 初始化驱动的 WS Reverse Client 连接
+     *
+     * @param array $headers 请求头
      */
-    abstract public function initWSReverseClients();
+    abstract public function initWSReverseClients(array $headers = []);
 
     /**
      * 驱动必须提供一个可以添加到对应驱动 EventLoop 的读接口

--- a/src/OneBot/Driver/Socket/HttpServerSocketBase.php
+++ b/src/OneBot/Driver/Socket/HttpServerSocketBase.php
@@ -8,4 +8,5 @@ use OneBot\Driver\Interfaces\SocketInterface;
 
 abstract class HttpServerSocketBase implements SocketInterface
 {
+    use SocketFlag;
 }

--- a/src/OneBot/Driver/Socket/HttpWebhookSocketBase.php
+++ b/src/OneBot/Driver/Socket/HttpWebhookSocketBase.php
@@ -16,6 +16,8 @@ use Throwable;
 
 abstract class HttpWebhookSocketBase implements SocketInterface
 {
+    use SocketFlag;
+
     protected $url;
 
     protected $headers;

--- a/src/OneBot/Driver/Socket/SocketFlag.php
+++ b/src/OneBot/Driver/Socket/SocketFlag.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OneBot\Driver\Socket;
+
+trait SocketFlag
+{
+    /** @var int */
+    protected $flag = 0;
+
+    public function setFlag(int $flag): self
+    {
+        $this->flag = $flag;
+        return $this;
+    }
+
+    public function getFlag(): int
+    {
+        return $this->flag;
+    }
+}

--- a/src/OneBot/Driver/Socket/WSReverseSocketBase.php
+++ b/src/OneBot/Driver/Socket/WSReverseSocketBase.php
@@ -7,9 +7,12 @@ namespace OneBot\Driver\Socket;
 use OneBot\Driver\Interfaces\SocketInterface;
 use OneBot\Driver\Interfaces\WebSocketClientInterface;
 use OneBot\Driver\Interfaces\WebSocketInterface;
+use OneBot\Http\WebSocket\FrameInterface;
 
 abstract class WSReverseSocketBase implements SocketInterface, WebSocketInterface
 {
+    use SocketFlag;
+
     protected $url;
 
     protected $headers;
@@ -59,5 +62,10 @@ abstract class WSReverseSocketBase implements SocketInterface, WebSocketInterfac
     public function getClient(): WebSocketClientInterface
     {
         return $this->client;
+    }
+
+    public function send(FrameInterface $data, $id = null): bool
+    {
+        return $this->client->send($data);
     }
 }

--- a/src/OneBot/Driver/Socket/WSServerSocketBase.php
+++ b/src/OneBot/Driver/Socket/WSServerSocketBase.php
@@ -10,6 +10,8 @@ use OneBot\Http\WebSocket\FrameInterface;
 
 abstract class WSServerSocketBase implements SocketInterface, WebSocketInterface
 {
+    use SocketFlag;
+
     abstract public function sendAll(FrameInterface $data): array;
 
     abstract public function close($id): bool;

--- a/src/OneBot/Driver/Swoole/Socket/WSReverseSocket.php
+++ b/src/OneBot/Driver/Swoole/Socket/WSReverseSocket.php
@@ -5,13 +5,7 @@ declare(strict_types=1);
 namespace OneBot\Driver\Swoole\Socket;
 
 use OneBot\Driver\Socket\WSReverseSocketBase;
-use OneBot\Http\WebSocket\FrameInterface;
 
 class WSReverseSocket extends WSReverseSocketBase
 {
-    public function send(FrameInterface $data, $id = null): bool
-    {
-        $this->client->send($data->getData());
-        return false;
-    }
 }

--- a/src/OneBot/Driver/SwooleDriver.php
+++ b/src/OneBot/Driver/SwooleDriver.php
@@ -62,7 +62,7 @@ class SwooleDriver extends Driver
             $this->server = new SwooleWebSocketServer($ws_0['host'], $ws_0['port'], $this->getParam('swoole_server_mode', SWOOLE_PROCESS));
             $this->initServer();
             $this->initWebSocketServer($this->server);
-            $this->ws_socket[] = new WSServerSocket($this->server, $ws_0);
+            $this->ws_socket[] = (new WSServerSocket($this->server, $ws_0))->setFlag(1);
             if (!empty($ws)) {
                 foreach ($ws as $v) {
                     $this->addWSServerListener($v);
@@ -78,7 +78,7 @@ class SwooleDriver extends Driver
             $this->server = new SwooleHttpServer($http_0['host'], $http_0['port'], $this->getParam('swoole_server_mode', SWOOLE_PROCESS));
             $this->initServer();
             $this->initHttpServer($this->server);
-            $this->http_socket[] = new HttpServerSocket($this->server, $http_0);
+            $this->http_socket[] = (new HttpServerSocket($this->server, $http_0))->setFlag(1);
             if (!empty($http)) {
                 foreach ($http as $v) {
                     $this->addHttpServerListener($v);
@@ -87,10 +87,10 @@ class SwooleDriver extends Driver
         }
         /* @noinspection DuplicatedCode */
         foreach ($http_webhook as $v) {
-            $this->http_webhook_socket[] = new HttpWebhookSocket($v['url'], $v['header'] ?? [], $v['access_token'] ?? '', $v['timeout'] ?? 5);
+            $this->http_webhook_socket[] = (new HttpWebhookSocket($v['url'], $v['header'] ?? [], $v['access_token'] ?? '', $v['timeout'] ?? 5))->setFlag(1);
         }
         foreach ($ws_reverse as $v) {
-            $this->ws_reverse_socket[] = new WSReverseSocket($v['url'], $v['header'] ?? [], $v['access_token'] ?? '', $v['reconnect_interval'] ?? 5);
+            $this->ws_reverse_socket[] = (new WSReverseSocket($v['url'], $v['header'] ?? [], $v['access_token'] ?? '', $v['reconnect_interval'] ?? 5))->setFlag(1);
         }
         return [$this->http_socket !== [], $this->http_webhook_socket !== [], $this->ws_socket !== [], $this->ws_reverse_socket !== []];
     }

--- a/src/OneBot/Driver/SwooleDriver.php
+++ b/src/OneBot/Driver/SwooleDriver.php
@@ -182,10 +182,10 @@ class SwooleDriver extends Driver
      *
      * @throws ClientException
      */
-    public function initWSReverseClients()
+    public function initWSReverseClients(array $headers = [])
     {
         foreach ($this->ws_reverse_socket as $v) {
-            $v->setClient(WebSocketClient::createFromAddress($v->getUrl(), $v->getHeaders(), $this->getParam('swoole_ws_client_set', ['websocket_mask' => true])));
+            $v->setClient(WebSocketClient::createFromAddress($v->getUrl(), array_merge($headers, $v->getHeaders()), $this->getParam('swoole_ws_client_set', ['websocket_mask' => true])));
         }
     }
 

--- a/src/OneBot/Driver/Workerman/Socket/WSReverseSocket.php
+++ b/src/OneBot/Driver/Workerman/Socket/WSReverseSocket.php
@@ -5,13 +5,7 @@ declare(strict_types=1);
 namespace OneBot\Driver\Workerman\Socket;
 
 use OneBot\Driver\Socket\WSReverseSocketBase;
-use OneBot\Http\WebSocket\FrameInterface;
 
 class WSReverseSocket extends WSReverseSocketBase
 {
-    public function send(FrameInterface $data, $id = null): bool
-    {
-        // TODO: 编写发送 ws_reverse 下给服务端传输的数据
-        return false;
-    }
 }

--- a/src/OneBot/Driver/WorkermanDriver.php
+++ b/src/OneBot/Driver/WorkermanDriver.php
@@ -205,8 +205,7 @@ class WorkermanDriver extends Driver
                         $worker = new Worker('websocket://' . $ws_1['host'] . ':' . $ws_1['port']);
                         $worker->reusePort = true;
                         $worker->token = ob_uuidgen();
-                        $this->ws_socket[] = new WSServerSocket($worker);
-
+                        $this->ws_socket[] = (new WSServerSocket($worker))->setFlag(1);
                         // ws server 相关事件
                         $worker->onWebSocketConnect = [TopEventListener::getInstance(), 'onWebSocketOpen'];
                         $worker->onClose = [TopEventListener::getInstance(), 'onWebSocketClose'];
@@ -215,7 +214,7 @@ class WorkermanDriver extends Driver
                     }
                 }, 999);
             }
-            $this->ws_socket[] = new WSServerSocket($worker);
+            $this->ws_socket[] = (new WSServerSocket($worker))->setFlag(1);
 
             if (!empty($http)) {
                 $http_in_worker_start_init = true;
@@ -236,7 +235,7 @@ class WorkermanDriver extends Driver
                 $worker->onWorkerStart = [TopEventListener::getInstance(), 'onWorkerStart'];
                 $worker->onWorkerStop = [TopEventListener::getInstance(), 'onWorkerStop'];
                 $worker->token = ob_uuidgen();
-                $this->http_socket[] = new HttpServerSocket($worker);
+                $this->http_socket[] = (new HttpServerSocket($worker))->setFlag(1);
             }
             if (!empty($http_pending)) {
                 EventProvider::addEventListener(WorkerStartEvent::getName(), function () use ($http_pending) {
@@ -245,7 +244,7 @@ class WorkermanDriver extends Driver
                         $worker = new Worker('http://' . $http_1['host'] . ':' . $http_1['port']);
                         $worker->reusePort = true;
                         $worker->token = ob_uuidgen();
-                        $this->http_socket[] = new HttpServerSocket($worker);
+                        $this->http_socket[] = (new HttpServerSocket($worker))->setFlag(1);
                         // http server 相关事件
                         $worker->onMessage = [TopEventListener::getInstance(), 'onHttpRequest'];
                         $worker->listen();
@@ -255,10 +254,10 @@ class WorkermanDriver extends Driver
         }
         /* @noinspection DuplicatedCode */
         foreach ($http_webhook as $v) {
-            $this->http_webhook_socket[] = new HttpWebhookSocket($v['url'], $v['header'] ?? [], $v['access_token'] ?? '', $v['timeout'] ?? 5);
+            $this->http_webhook_socket[] = (new HttpWebhookSocket($v['url'], $v['header'] ?? [], $v['access_token'] ?? '', $v['timeout'] ?? 5))->setFlag(1);
         }
         foreach ($ws_reverse as $v) {
-            $this->ws_reverse_socket[] = new WSReverseSocket($v['url'], $v['header'] ?? [], $v['access_token'] ?? '', $v['reconnect_interval'] ?? 5);
+            $this->ws_reverse_socket[] = (new WSReverseSocket($v['url'], $v['header'] ?? [], $v['access_token'] ?? '', $v['reconnect_interval'] ?? 5))->setFlag(1);
         }
         return [$this->http_socket !== [], $this->http_webhook_socket !== [], $this->ws_socket !== [], $this->ws_reverse_socket !== []];
     }

--- a/src/OneBot/Driver/WorkermanDriver.php
+++ b/src/OneBot/Driver/WorkermanDriver.php
@@ -154,10 +154,10 @@ class WorkermanDriver extends Driver
      *
      * @throws Exception
      */
-    public function initWSReverseClients()
+    public function initWSReverseClients(array $headers = [])
     {
         foreach ($this->ws_reverse_socket as $v) {
-            $v->setClient(WebSocketClient::createFromAddress($v->getUrl(), $v->getHeaders()));
+            $v->setClient(WebSocketClient::createFromAddress($v->getUrl(), array_merge($headers, $v->getHeaders())));
         }
     }
 

--- a/src/OneBot/V12/OneBotEventListener.php
+++ b/src/OneBot/V12/OneBotEventListener.php
@@ -144,7 +144,7 @@ class OneBotEventListener
     public function onDriverInit(DriverInitEvent $event)
     {
         ob_logger()->info('初始化 ws reverse 连接 ing');
-        $event->getDriver()->ws_reverse_client = $event->getDriver()->initWSReverseClients();
+        $event->getDriver()->initWSReverseClients(OneBot::getInstance()->getRequestHeaders());
         foreach ($event->getDriver()->getWSReverseSockets() as $k => $v) {
             $reconnect = function () use ($v, $event, &$reconnect) {
                 try {


### PR DESCRIPTION
Socket Flag 的作用是对实现协议的时候复用通信方式的一个支持，例如开启一个非 OneBotConnect 的 HTTP 服务器用于接收其他 IM 的事件推送，这样可与 OneBot 12 本身解藕，也就是相当于可自行添加一个额外的通信方式并启动，而 libob 对自定义添加的这个 Socket 为默认 Flag（默认为 0，如果是 OneBot 配置的通信方式 Socket 的 Flag 则为 1）不会对其转发。