### PR TITLE
Remove coroutine support for workerStop

### DIFF
--- a/src/OneBot/Driver/Workerman/TopEventListener.php
+++ b/src/OneBot/Driver/Workerman/TopEventListener.php
@@ -47,11 +47,7 @@ class TopEventListener
      */
     public function onWorkerStop()
     {
-        if (($co = Adaptive::getCoroutine()) !== null) {
-            $co->create(fn () => ob_event_dispatcher()->dispatchWithHandler(new WorkerStopEvent()));
-        } else {
-            ob_event_dispatcher()->dispatchWithHandler(new WorkerStopEvent());
-        }
+        ob_event_dispatcher()->dispatchWithHandler(new WorkerStopEvent());
     }
 
     /**

--- a/src/OneBot/global_defines.php
+++ b/src/OneBot/global_defines.php
@@ -13,7 +13,7 @@ use Psr\Log\LoggerInterface;
 use ZM\Logger\ConsoleLogger;
 
 const ONEBOT_VERSION = '12';
-const ONEBOT_LIBOB_VERSION = '0.6.4';
+const ONEBOT_LIBOB_VERSION = '0.6.5';
 
 const ONEBOT_JSON = 1;
 const ONEBOT_MSGPACK = 2;


### PR DESCRIPTION
新版本的 Workerman 如果在 调用 stopAll 停服后，workerStop 事件中包含了 Fiber，会引起递归报错。