### PR TITLE
Fix top event throws uncaught exceptions

### DIFF
--- a/src/OneBot/Config/Loader/AbstractFileLoader.php
+++ b/src/OneBot/Config/Loader/AbstractFileLoader.php
@@ -9,9 +9,6 @@ use OneBot\Util\Utils;
 
 abstract class AbstractFileLoader implements LoaderInterface
 {
-    /**
-     * {@inheritDoc}
-     */
     public function load($source): array
     {
         // TODO: flexible base path

--- a/src/OneBot/Config/Loader/DelegateLoader.php
+++ b/src/OneBot/Config/Loader/DelegateLoader.php
@@ -25,9 +25,6 @@ class DelegateLoader implements LoaderInterface
         $this->loaders = $loaders ?? self::getDefaultLoaders();
     }
 
-    /**
-     * {@inheritDoc}
-     */
     public function load($source): array
     {
         return $this->determineLoader($source)->load($source);

--- a/src/OneBot/Config/Loader/JsonFileLoader.php
+++ b/src/OneBot/Config/Loader/JsonFileLoader.php
@@ -6,9 +6,6 @@ namespace OneBot\Config\Loader;
 
 class JsonFileLoader extends AbstractFileLoader
 {
-    /**
-     * {@inheritDoc}
-     */
     protected function loadFile(string $file)
     {
         try {

--- a/src/OneBot/Config/Repository.php
+++ b/src/OneBot/Config/Repository.php
@@ -21,9 +21,6 @@ class Repository implements RepositoryInterface
         $this->config = $config;
     }
 
-    /**
-     * {@inheritDoc}
-     */
     public function get(string $key, $default = null)
     {
         // 在表层直接查找，找到就直接返回
@@ -51,9 +48,6 @@ class Repository implements RepositoryInterface
         return $data;
     }
 
-    /**
-     * {@inheritDoc}
-     */
     public function set(string $key, $value): void
     {
         if ($value === null) {
@@ -75,17 +69,11 @@ class Repository implements RepositoryInterface
         $data = $value;
     }
 
-    /**
-     * {@inheritDoc}
-     */
     public function has(string $key): bool
     {
         return $this->get($key) !== null;
     }
 
-    /**
-     * {@inheritDoc}
-     */
     public function all(): array
     {
         return $this->config;

--- a/src/OneBot/Driver/Event/DriverEvent.php
+++ b/src/OneBot/Driver/Event/DriverEvent.php
@@ -24,9 +24,6 @@ abstract class DriverEvent implements Event, StoppableEventInterface
         return static::$custom_name ?? static::class;
     }
 
-    /**
-     * {@inheritDoc}
-     */
     public function isPropagationStopped(): bool
     {
         return $this->propagation_stopped;

--- a/src/OneBot/Driver/Swoole/EventLoop.php
+++ b/src/OneBot/Driver/Swoole/EventLoop.php
@@ -10,17 +10,11 @@ use Swoole\Timer;
 
 class EventLoop extends DriverEventLoopBase
 {
-    /**
-     * {@inheritDoc}
-     */
     public function addReadEvent($fd, callable $callable)
     {
         Event::add($fd, $callable);
     }
 
-    /**
-     * {@inheritDoc}
-     */
     public function delReadEvent($fd)
     {
         Event::del($fd);
@@ -36,9 +30,6 @@ class EventLoop extends DriverEventLoopBase
         Event::del($fd);
     }
 
-    /**
-     * {@inheritDoc}
-     */
     public function addTimer(int $ms, callable $callable, int $times = 1, array $arguments = []): int
     {
         $timer_count = 0;
@@ -54,17 +45,11 @@ class EventLoop extends DriverEventLoopBase
         }, ...$arguments);
     }
 
-    /**
-     * {@inheritDoc}
-     */
     public function clearTimer(int $timer_id)
     {
         Timer::clear($timer_id);
     }
 
-    /**
-     * {@inheritDoc}
-     */
     public function clearAllTimer()
     {
         Timer::clearAll();

--- a/src/OneBot/Driver/Swoole/Socket/WSServerSocket.php
+++ b/src/OneBot/Driver/Swoole/Socket/WSServerSocket.php
@@ -27,9 +27,6 @@ class WSServerSocket extends WSServerSocketBase
         return false;
     }
 
-    /**
-     * {@inheritDoc}
-     */
     public function send($data, $fd): bool
     {
         if ($data instanceof FrameInterface) {

--- a/src/OneBot/Driver/Swoole/SwooleDriver.php
+++ b/src/OneBot/Driver/Swoole/SwooleDriver.php
@@ -59,9 +59,6 @@ class SwooleDriver extends Driver
         return EventLoop::getInstance();
     }
 
-    /**
-     * {@inheritDoc}
-     */
     public function initInternalDriverClasses(?array $http, ?array $http_webhook, ?array $ws, ?array $ws_reverse): array
     {
         if (!empty($ws)) {

--- a/src/OneBot/Driver/Workerman/EventLoop.php
+++ b/src/OneBot/Driver/Workerman/EventLoop.php
@@ -10,9 +10,6 @@ use Workerman\Timer;
 
 class EventLoop extends DriverEventLoopBase
 {
-    /**
-     * {@inheritDoc}
-     */
     public function addTimer(int $ms, callable $callable, int $times = 1, array $arguments = []): int
     {
         $timer_count = 0;
@@ -28,49 +25,31 @@ class EventLoop extends DriverEventLoopBase
         }, $arguments);
     }
 
-    /**
-     * {@inheritDoc}
-     */
     public function clearTimer(int $timer_id)
     {
         Timer::del($timer_id);
     }
 
-    /**
-     * {@inheritDoc}
-     */
     public function addReadEvent($fd, callable $callable)
     {
         Worker::getEventLoop()->add($fd, EventInterface::EV_READ, $callable);
     }
 
-    /**
-     * {@inheritDoc}
-     */
     public function delReadEvent($fd)
     {
         Worker::getEventLoop()->del($fd, EventInterface::EV_READ);
     }
 
-    /**
-     * {@inheritDoc}
-     */
     public function addWriteEvent($fd, callable $callable)
     {
         Worker::getEventLoop()->add($fd, EventInterface::EV_WRITE, $callable);
     }
 
-    /**
-     * {@inheritDoc}
-     */
     public function delWriteEvent($fd)
     {
         Worker::getEventLoop()->del($fd, EventInterface::EV_WRITE);
     }
 
-    /**
-     * {@inheritDoc}
-     */
     public function clearAllTimer()
     {
         Timer::delAll();

--- a/src/OneBot/Driver/Workerman/Worker.php
+++ b/src/OneBot/Driver/Workerman/Worker.php
@@ -117,7 +117,7 @@ class Worker extends \Workerman\Worker
             }
             foreach ($worker_pid_array as $worker_pid) {
                 \posix_kill($worker_pid, $sig);
-                if (!static::$_gracefulStop){
+                if (!static::$_gracefulStop) {
                     Timer::add(static::$stopTimeout, '\posix_kill', [$worker_pid, \SIGKILL], false);
                 }
             }
@@ -130,7 +130,7 @@ class Worker extends \Workerman\Worker
         else {
             // Execute exit.
             foreach (static::$_workers as $worker) {
-                if (!$worker->stopping){
+                if (!$worker->stopping) {
                     $worker->stop();
                     $worker->stopping = true;
                 }
@@ -156,7 +156,8 @@ class Worker extends \Workerman\Worker
      *
      * @return array
      */
-    public static function getStartFilesForWindows() {
+    public static function getStartFilesForWindows()
+    {
         return [''];
     }
 
@@ -303,7 +304,7 @@ class Worker extends \Workerman\Worker
                     }
                     static::safeEcho("\nPress Ctrl+C to quit.\n\n");
                 }
-            // no break
+                // no break
             case 'connections':
                 if (\is_file($statistics_file) && is_writable($statistics_file)) {
                     \unlink($statistics_file);

--- a/src/OneBot/Driver/Workerman/WorkermanDriver.php
+++ b/src/OneBot/Driver/Workerman/WorkermanDriver.php
@@ -58,9 +58,6 @@ class WorkermanDriver extends Driver
         return null;
     }
 
-    /**
-     * {@inheritDoc}
-     */
     public function run(): void
     {
         try {
@@ -121,8 +118,6 @@ class WorkermanDriver extends Driver
     }
 
     /**
-     * {@inheritDoc}
-     *
      * @throws \Exception
      */
     public function initWSReverseClients(array $headers = [])

--- a/src/OneBot/V12/EventBuilder.php
+++ b/src/OneBot/V12/EventBuilder.php
@@ -36,7 +36,7 @@ class EventBuilder
         try {
             $this->event = new OneBotEvent($this->data);
             return true;
-        }catch (OneBotException $e) {
+        } catch (OneBotException $e) {
             return false;
         }
     }

--- a/src/OneBot/global_defines.php
+++ b/src/OneBot/global_defines.php
@@ -13,7 +13,7 @@ use Psr\Log\LoggerInterface;
 use ZM\Logger\ConsoleLogger;
 
 const ONEBOT_VERSION = '12';
-const ONEBOT_LIBOB_VERSION = '0.6.6';
+const ONEBOT_LIBOB_VERSION = '0.6.7';
 
 const ONEBOT_JSON = 1;
 const ONEBOT_MSGPACK = 2;

--- a/tests/OneBot/Config/RepositoryTest.php
+++ b/tests/OneBot/Config/RepositoryTest.php
@@ -49,12 +49,12 @@ class RepositoryTest extends TestCase
         );
     }
 
-// 尚未确定是否应该支持
-//    public function testGetValueWhenKeyContainsDot(): void
-//    {
-//        $this->assertEquals('c', $this->repository->get('a.b'));
-//        $this->assertEquals('d', $this->repository->get('a.b.c'));
-//    }
+    // 尚未确定是否应该支持
+    //    public function testGetValueWhenKeyContainsDot(): void
+    //    {
+    //        $this->assertEquals('c', $this->repository->get('a.b'));
+    //        $this->assertEquals('d', $this->repository->get('a.b.c'));
+    //    }
 
     public function testGetBooleanValue(): void
     {


### PR DESCRIPTION
某些情况下，内部的组件例如 `choir/psr-http`、`symfony/route` 等抛出了异常，可能无法正常捕获，从而导致整个 Driver 直接退出崩溃。